### PR TITLE
 Rename ThrowableErrorHandler to BlockingErrorHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ composer require wecodein/error-handling
 ``` php
 use WeCodeIn\ErrorHandling\Handler\ExceptionHandler;
 use WeCodeIn\ErrorHandling\Handler\FatalErrorHandler;
-use WeCodeIn\ErrorHandling\Handler\ThrowableErrorHandler;
+use WeCodeIn\ErrorHandling\Handler\BlockingErrorHandler;
 use WeCodeIn\ErrorHandling\Processor\CallableProcessor;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -34,7 +34,7 @@ $processor = new CallableProcessor(function (Throwable $throwable) : Throwable {
     return $throwable;
 });
 
-$errorHandler = new ThrowableErrorHandler();
+$errorHandler = new BlockingErrorHandler();
 $errorHandler->register();
 
 $exceptionHandler = new ExceptionHandler($processor);

--- a/examples/usage-with-throwable-error-handler.php
+++ b/examples/usage-with-throwable-error-handler.php
@@ -2,7 +2,7 @@
 
 use WeCodeIn\ErrorHandling\Handler\ExceptionHandler;
 use WeCodeIn\ErrorHandling\Handler\FatalErrorHandler;
-use WeCodeIn\ErrorHandling\Handler\ThrowableErrorHandler;
+use WeCodeIn\ErrorHandling\Handler\BlockingErrorHandler;
 use WeCodeIn\ErrorHandling\Processor\CallableProcessor;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -17,7 +17,7 @@ $processor = new CallableProcessor(function (Throwable $throwable) : Throwable {
     return $throwable;
 });
 
-$errorHandler = new ThrowableErrorHandler();
+$errorHandler = new BlockingErrorHandler();
 $errorHandler->register();
 
 $exceptionHandler = new ExceptionHandler($processor);

--- a/src/Handler/BlockingErrorHandler.php
+++ b/src/Handler/BlockingErrorHandler.php
@@ -14,7 +14,7 @@ namespace WeCodeIn\ErrorHandling\Handler;
 
 use Throwable;
 
-class ThrowableErrorHandler extends AbstractErrorHandler
+class BlockingErrorHandler extends AbstractErrorHandler
 {
     protected function handle(Throwable $throwable)
     {

--- a/src/Processor/CallableProcessor.php
+++ b/src/Processor/CallableProcessor.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace WeCodeIn\ErrorHandling\Processor;
 
+use Throwable;
+
 class CallableProcessor implements ProcessorInterface
 {
     protected $callable;
@@ -21,7 +23,7 @@ class CallableProcessor implements ProcessorInterface
         $this->callable = $callable;
     }
 
-    public function __invoke(\Throwable $throwable) : \Throwable
+    public function __invoke(Throwable $throwable) : Throwable
     {
         return ($this->callable)($throwable);
     }

--- a/src/Processor/ProcessorInterface.php
+++ b/src/Processor/ProcessorInterface.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace WeCodeIn\ErrorHandling\Processor;
 
+use Throwable;
+
 interface ProcessorInterface
 {
-    public function __invoke(\Throwable $throwable) : \Throwable;
+    public function __invoke(Throwable $throwable) : Throwable;
 }

--- a/tests/Handler/BlockingErrorHandlerTest.php
+++ b/tests/Handler/BlockingErrorHandlerTest.php
@@ -7,9 +7,9 @@ use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Throwable;
-use WeCodeIn\ErrorHandling\Handler\ThrowableErrorHandler;
+use WeCodeIn\ErrorHandling\Handler\BlockingErrorHandler;
 
-final class ThrowableErrorHandlerTest extends TestCase
+final class BlockingErrorHandlerTest extends TestCase
 {
     use PHPMock;
 
@@ -32,7 +32,7 @@ final class ThrowableErrorHandlerTest extends TestCase
 
     public function testThrowsExceptionOnError()
     {
-        $errorHandler = new ThrowableErrorHandler();
+        $errorHandler = new BlockingErrorHandler();
         $errorHandler->register();
 
         $this->expectException(Throwable::class);
@@ -47,7 +47,7 @@ final class ThrowableErrorHandlerTest extends TestCase
 
     protected function getErrorHandlerReflectionClass()
     {
-        return new ReflectionClass(ThrowableErrorHandler::class);
+        return new ReflectionClass(BlockingErrorHandler::class);
     }
 
     protected function triggerPHPError()


### PR DESCRIPTION
- rename ThrowableErrorHandler to BlockingErrorHandler
- import used classes instead of using FQCN in the code