### PR TITLE
Dismiss ProcessableTrait in favor of a AbstractProcessingHandler class

### DIFF
--- a/src/Handler/AbstractErrorHandler.php
+++ b/src/Handler/AbstractErrorHandler.php
@@ -15,7 +15,7 @@ namespace WeCodeIn\ErrorHandling\Handler;
 use ErrorException;
 use Throwable;
 
-abstract class AbstractErrorHandler extends AbstractHandler
+abstract class AbstractErrorHandler extends AbstractProcessingHandler
 {
     protected function registerListener()
     {

--- a/src/Handler/AbstractProcessingHandler.php
+++ b/src/Handler/AbstractProcessingHandler.php
@@ -14,12 +14,7 @@ abstract class AbstractProcessingHandler extends AbstractHandler
      */
     private $processors;
 
-    public function __construct(array $processors = [])
-    {
-        $this->setProcessors(...$processors);
-    }
-
-    private function setProcessors(ProcessorInterface ...$processors)
+    public function __construct(ProcessorInterface ...$processors)
     {
         $this->processors = $processors;
     }

--- a/src/Handler/AbstractProcessingHandler.php
+++ b/src/Handler/AbstractProcessingHandler.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * This file is part of the error-handling package.
- *
- * Copyright (c) Dusan Vejin
- *
- * For full copyright and license information, please refer to the LICENSE file,
- * located at the package root folder.
- */
 
 declare(strict_types=1);
 
@@ -15,12 +7,19 @@ namespace WeCodeIn\ErrorHandling\Handler;
 use Throwable;
 use WeCodeIn\ErrorHandling\Processor\ProcessorInterface;
 
-trait ProcessableTrait
+abstract class AbstractProcessingHandler extends AbstractHandler
 {
-    /** @var ProcessorInterface[] */
-    private $processors = [];
+    /**
+     * @var ProcessorInterface[]
+     */
+    private $processors;
 
-    protected function setProcessors(ProcessorInterface ...$processors)
+    public function __construct(array $processors = [])
+    {
+        $this->setProcessors(...$processors);
+    }
+
+    private function setProcessors(ProcessorInterface ...$processors)
     {
         $this->processors = $processors;
     }

--- a/src/Handler/ErrorHandler.php
+++ b/src/Handler/ErrorHandler.php
@@ -13,17 +13,9 @@ declare(strict_types=1);
 namespace WeCodeIn\ErrorHandling\Handler;
 
 use Throwable;
-use WeCodeIn\ErrorHandling\Processor\ProcessorInterface;
 
 class ErrorHandler extends AbstractErrorHandler
 {
-    use ProcessableTrait;
-
-    public function __construct(ProcessorInterface ...$processors)
-    {
-        $this->setProcessors(...$processors);
-    }
-
     protected function handle(Throwable $throwable)
     {
         $this->process($throwable);

--- a/src/Handler/ExceptionHandler.php
+++ b/src/Handler/ExceptionHandler.php
@@ -13,17 +13,9 @@ declare(strict_types=1);
 namespace WeCodeIn\ErrorHandling\Handler;
 
 use Throwable;
-use WeCodeIn\ErrorHandling\Processor\ProcessorInterface;
 
-class ExceptionHandler extends AbstractHandler
+class ExceptionHandler extends AbstractProcessingHandler
 {
-    use ProcessableTrait;
-
-    public function __construct(ProcessorInterface ...$processors)
-    {
-        $this->setProcessors(...$processors);
-    }
-
     protected function registerListener()
     {
         set_exception_handler($this);

--- a/src/Handler/FatalErrorHandler.php
+++ b/src/Handler/FatalErrorHandler.php
@@ -14,14 +14,15 @@ namespace WeCodeIn\ErrorHandling\Handler;
 
 use ErrorException;
 use Throwable;
+use WeCodeIn\ErrorHandling\Processor\ProcessorInterface;
 
 class FatalErrorHandler extends AbstractErrorHandler
 {
     private $allocatedMemory;
 
-    public function __construct(int $allocatedMemorySize, array $processors = [])
+    public function __construct(int $allocatedMemorySize, ProcessorInterface ...$processors)
     {
-        parent::__construct($processors);
+        parent::__construct(...$processors);
 
         $this->allocatedMemory = str_repeat(' ', 1024 * $allocatedMemorySize);
     }

--- a/src/Handler/FatalErrorHandler.php
+++ b/src/Handler/FatalErrorHandler.php
@@ -14,18 +14,16 @@ namespace WeCodeIn\ErrorHandling\Handler;
 
 use ErrorException;
 use Throwable;
-use WeCodeIn\ErrorHandling\Processor\ProcessorInterface;
 
 class FatalErrorHandler extends AbstractErrorHandler
 {
-    use ProcessableTrait;
-
     private $allocatedMemory;
 
-    public function __construct(int $allocatedMemorySize, ProcessorInterface ...$processors)
+    public function __construct(int $allocatedMemorySize, array $processors = [])
     {
+        parent::__construct($processors);
+
         $this->allocatedMemory = str_repeat(' ', 1024 * $allocatedMemorySize);
-        $this->setProcessors(...$processors);
     }
 
     protected function registerListener()

--- a/tests/Handler/AbstractErrorHandlerTest.php
+++ b/tests/Handler/AbstractErrorHandlerTest.php
@@ -7,7 +7,6 @@ use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass;
-use Throwable;
 use WeCodeIn\ErrorHandling\Handler\AbstractErrorHandler;
 
 final class AbstractErrorHandlerTest extends TestCase

--- a/tests/Handler/ErrorHandlerTest.php
+++ b/tests/Handler/ErrorHandlerTest.php
@@ -47,7 +47,7 @@ final class ErrorHandlerTest extends TestCase
             }),
         ];
 
-        $handler = new ErrorHandler($processors);
+        $handler = new ErrorHandler(...$processors);
         $handler->register();
 
         $this->triggerPHPError();

--- a/tests/Handler/ExceptionHandlerTest.php
+++ b/tests/Handler/ExceptionHandlerTest.php
@@ -68,7 +68,7 @@ final class ExceptionHandlerTest extends TestCase
             }),
         ];
 
-        $handler = new ExceptionHandler($processors);
+        $handler = new ExceptionHandler(...$processors);
         $handler->register();
         $handler(new Exception());
     }

--- a/tests/Handler/FatalErrorHandlerTest.php
+++ b/tests/Handler/FatalErrorHandlerTest.php
@@ -58,7 +58,7 @@ final class FatalErrorHandlerTest extends TestCase
             }),
         ];
 
-        $errorHandler = new FatalErrorHandler(10, $processors);
+        $errorHandler = new FatalErrorHandler(10, ...$processors);
         $errorHandler->register();
 
         $this->triggerPHPShutdown();
@@ -70,7 +70,7 @@ final class FatalErrorHandlerTest extends TestCase
         $processor->expects($this->never())
             ->method('__invoke');
 
-        $errorHandler = new FatalErrorHandler(10, [$processor]);
+        $errorHandler = new FatalErrorHandler(10, $processor);
         $errorHandler->register();
         $errorHandler->restore();
 


### PR DESCRIPTION
- dismiss `ProcessableTrait` in favor of a `AbstractProcessingHandler` class for better construction logic reuse
- improve tests quality/speed by using real objects instead of mocks
- remove duplicated tests